### PR TITLE
Monitor all folder for scss calls.

### DIFF
--- a/CSS/sass/sass.js
+++ b/CSS/sass/sass.js
@@ -6,7 +6,7 @@ var fs = require('fs');
 
 exports.install = function() {
 
-	F.file('*.scss', scss_compiler);
+	F.file('/*.*', scss_compiler, ['.scss']); // Monitor all folders for changes.
 
 	F.config['static-accepts']['.scss'] = true;
 


### PR DESCRIPTION
This resolves a bug where if the file is in a /scss or /css folder it is not read. This amends the F.file to handle any .scss files in any subdirs.